### PR TITLE
Fix wrong port in debug log

### DIFF
--- a/tnat64.c
+++ b/tnat64.c
@@ -218,7 +218,7 @@ int connect(CONNECT_SIGNATURE)
     /* If we haven't initialized yet, do it now */
     get_config();
 
-    show_msg(MSGDEBUG, "Got connection request for socket %d to " "%s:%d\n", __fd, inet_ntoa(connaddr->sin_addr), connaddr->sin_port);
+    show_msg(MSGDEBUG, "Got connection request for socket %d to " "%s:%d\n", __fd, inet_ntoa(connaddr->sin_addr), ntohs(connaddr->sin_port));
 
     /* If the address is local call realconnect */
     if (!(is_local(config, &(connaddr->sin_addr))))


### PR DESCRIPTION
Small bug I found during testing: The debug output doesn't display the destination port correctly because it's stored in big-endian (network byte order) but read as little-endian. 

Modifying the `show_msg` function call to use `ntohs(connaddr->sin_port)` instead of just `connaddr->sin_port` fixes this. 