### PR TITLE
Make local connections use AF_INET6, too

### DIFF
--- a/tnat64.c
+++ b/tnat64.c
@@ -175,7 +175,20 @@ int socket(SOCKET_SIGNATURE)
     }
     if ((__domain == AF_INET) && ((__type & SOCK_TYPE_MASK) == SOCK_STREAM))
     {
-        return realsocket(AF_INET6, __type, __protocol);
+        int sock = realsocket(AF_INET6, __type, __protocol);
+
+        if (sock < 0) {
+            return sock;
+        }
+
+        // Now set this IPv6 socket to allow both IPv6 and IPv4 connections. 
+        // Most OSes do that by default, but not all. 
+        int no = 0;
+        if (setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (void*)&no, sizeof(no)) < 0) {
+            show_msg(MSGDEBUG, "Failed to disable IPV6_V6ONLY for socket %d: error %d (%s)\n", sock, errno, strerror(errno));
+        }
+
+        return sock;
     }
     else
     {


### PR DESCRIPTION
As mentioned in issue #4, when I try to perform a TCP connection to localhost, this fails because an IPv6 AF_INET6 socket (as created by tnat64) can't connect to an AF_INET IPv4 destination. 

This is fixed by: 

- setting the socket option `IPV6_V6ONLY` to false after creating an IPv6 socket - this is the default on most systems but not on all, and it makes sure that this IPv6 socket allows to connect to IPv4 destinations, too; and
- by adding the IPv4-mapped prefix `::ffff:` in front of the IPv4 address destination for local destinations so that an IPv6 socket can accept it. 

With this PR, `LD_PRELOAD=libtnat64.so telnet 127.0.0.1 22` works while it previously failed.