### PR TITLE
Fix buffer size issue for AF_NETLINK

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,10 +39,11 @@ dist_man_MANS = tnat64.1 tnat64.conf.5 tnat64-validateconf.1
 
 dist_doc_DATA = tnat64.conf.complex.example tnat64.conf.simple.example
 
-export DIG NSLOOKUP NETCAT
+export DIG NSLOOKUP NETCAT PYTHON
 
 export objdir = .libs
-TESTS = tests/01-correct-ipv6-address tests/02-local-connection
+TESTS = tests/01-correct-ipv6-address tests/02-local-connection \
+		tests/03-check-netlink-getsockname
 
 install-exec-hook:
 	cd $(DESTDIR)$(pkglibdir) && \

--- a/configure.ac
+++ b/configure.ac
@@ -352,6 +352,9 @@ fi
 
 
 dnl See if we can run tests
+
+AC_CHECK_PROGS(PYTHON, [python3 python python2.7])
+
 AC_CHECK_PROG(DIG, dig, dig)
 if test -z "$DIG"
 then

--- a/tests/01-correct-ipv6-address
+++ b/tests/01-correct-ipv6-address
@@ -1,5 +1,7 @@
 #!/bin/sh -e
 
+# Test for github bug #1.
+
 if [ -z "$DIG" ] && [ -z "$NSLOOKUP" ]
 then
   exit 77
@@ -16,8 +18,8 @@ else
 fi
 
 TNAT64_DEBUG=10 LD_PRELOAD=$objdir/libtnat64.so $TOOL example.org ${P}0.0.0.0 2>&1 | awk '
-BEGIN { e = 1 }
-/Checking if IPv6 address :: is behind the NAT64.../ { e = 0 }
+BEGIN { e = 0 }
+/Checking if IPv6 address :: is behind the NAT64.../ { e = 1 }
 //
 END { exit e }
 '

--- a/tests/03-check-netlink-getsockname
+++ b/tests/03-check-netlink-getsockname
@@ -1,0 +1,30 @@
+#!/bin/sh -e
+
+# Test for github bug #6 - ensure that NETLINK works.
+
+if [ -z "$PYTHON" ]
+then
+  exit 77
+fi
+
+: ${objdir:=.}
+
+TNAT64_DEBUG=10 LD_PRELOAD=$objdir/libtnat64.so $PYTHON << EOF
+
+import sys, socket, traceback
+
+def code():
+    sock = socket.socket(socket.AF_NETLINK, socket.SOCK_RAW)
+    print("sock is " + str(sock))
+
+    try:
+        sockname = sock.getsockname()
+        print("Success: sockname=" + str(sockname))
+        sock.close()
+        return
+    except:
+        traceback.print_exc()
+        sys.exit(42)
+
+code()
+EOF

--- a/tnat64.c
+++ b/tnat64.c
@@ -519,7 +519,7 @@ int connect(CONNECT_SIGNATURE)
                     int sockopt = -1;
                     socklen_t len = sizeof(sockopt);
                     if (getsockopt(__fd, IPPROTO_IPV6, IPV6_V6ONLY, (void*)&sockopt, &len) < 0) {
-                        show_msg(MSGWARN, "Can't figure out if this IPv6 socket supports IPv4, assume yes - error %d (%s)\n", errno, strerror(errno));
+                        show_msg(MSGWARN, "Can't figure out if this IPv6 socket supports IPv4, assuming it does (error %d: %s)\n", errno, strerror(errno));
                     }
 
                     if (sockopt != 1) {

--- a/tnat64.c
+++ b/tnat64.c
@@ -394,13 +394,13 @@ int connect(CONNECT_SIGNATURE)
         /* Rewrite to an IPv6 socket connect */
 
         // Check if this socket can send data to IPv4 addresses or if that's disabled: 
-        int sockopt = -1;
+        int sockopt = 0;
         socklen_t len = sizeof(sockopt);
         if (getsockopt(__fd, IPPROTO_IPV6, IPV6_V6ONLY, (void*)&sockopt, &len) < 0) {
-            show_msg(MSGWARN, "Can't figure out if this IPv6 socket supports IPv4, assume yes - error %d (%s)\n", errno, strerror(errno));
+            show_msg(MSGWARN, "Can't figure out if this IPv6 socket supports IPv4, assume it does - error %d (%s)\n", errno, strerror(errno));
         }
 
-        if (sockopt != 1) {
+        if (sockopt == 0) {
             // IPv6 socket supports IPv4 because the V6ONLY flag is not 1. 
 
             dest_address6.sin6_family = AF_INET6;
@@ -518,13 +518,13 @@ int connect(CONNECT_SIGNATURE)
                     // If the socket does NOT support IPv4 destinations, there's
                     // no need to try to connect to one - just return an error.
 
-                    int sockopt = -1;
+                    int sockopt = 0;
                     socklen_t len = sizeof(sockopt);
                     if (getsockopt(__fd, IPPROTO_IPV6, IPV6_V6ONLY, (void*)&sockopt, &len) < 0) {
                         show_msg(MSGWARN, "Can't figure out if this IPv6 socket supports IPv4, assuming it does (error %d: %s)\n", errno, strerror(errno));
                     }
 
-                    if (sockopt != 1) {
+                    if (sockopt == 0) {
                         // IPv6 socket supports IPv4 because the V6ONLY flag is not 1. 
                         current_af = AF_INET;
                     }

--- a/tnat64.c
+++ b/tnat64.c
@@ -498,10 +498,12 @@ int connect(CONNECT_SIGNATURE)
 
                 if (realconnect(__fd, (struct sockaddr *)&dest_address6, sizeof(struct sockaddr_in6)) == 0)
                 {
+                    show_msg(MSGDEBUG, "Connected successfully.\n");
                     return 0;
                 }
                 if (errno != ENETUNREACH)
                 {
+                    show_msg(MSGDEBUG, "Connect failed with errno=%d\n", errno);
                     return -1;
                 }
                 else
@@ -691,6 +693,7 @@ int getsockname(GETSOCKNAME_SIGNATURE)
     if (ret < 0) {
         // If we end up here, it's not because of a too-small buffer, 
         // because sockaddr_storage is the largest possible one.
+        show_msg(MSGDEBUG, "realgetsockname(%d) returned %d\n", __fd, ret);
         return ret;
     }   
 


### PR DESCRIPTION
This should hopefully fix #5 in all cases, by almost completely rewriting getsockname and getpeername It does fix the issue with AF_NETLINK I had with my application in particular. 

It also fixes another issue with the buffer size. Previously, if the `__addr` buffer in `getsockname` or `getpeername` was too small for the struct, your code just aborted and returned -1. 

According to [the documentation](https://man7.org/linux/man-pages/man2/getsockname.2.html) though, the returned data is supposed to be truncated to fit into the buffer, and the real needed buffer size is supposed to be returned through `__len` so the calling application can either decide to retry with a larger buffer, or be satisfied with the partial response. 

Also, `getsockname` is the IP address the local side of the socket is working on/with (your IP). So if you open a socket and connect to a remote server, getsockname is supposed to return your own IP. What happens currently is that in this case the library just "throws" the IPv6 address back to the application, which is probably not going to end well when an IPv4-only application actually tries to use this. I've modded it to return the IPv4 address 0.0.0.0 instead for the local socket. 