### PR TITLE
Fix a mess with exported symbols

### DIFF
--- a/common.c
+++ b/common.c
@@ -18,12 +18,14 @@
 #include <netinet/in.h>
 
 /* Globals */
-int loglevel = MSGERR;          /* The default logging level is to only log
+static int loglevel = MSGERR;          /* The default logging level is to only log
                                    error messages */
-char *logfilename = NULL;       /* Name of file to which log messages should
+static char *logfilename = NULL;       /* Name of file to which log messages should
                                    be redirected */
-FILE *logfile = NULL;           /* File to which messages should be logged */
-int logstamp = 0;               /* Timestamp (and pid stamp) messages */
+static FILE *logfile = NULL;           /* File to which messages should be logged */
+static int logstamp = 0;               /* Timestamp (and pid stamp) messages */
+
+static char *logprogname = NULL;
 
 unsigned int HIDDENSYM resolve_ip(char *host, int showmsg, int allownames)
 {
@@ -67,16 +69,22 @@ unsigned int HIDDENSYM resolve_ip(char *host, int showmsg, int allownames)
 /*          MSGWARN a call to log a message of level MSGDEBUG   */
 /*          would be ignored. This can be set to -1 to disable  */
 /*          messages entirely                                   */
+/*  progname - Program name prefixed to all log messages        */
 /*  filename - This is a filename to which the messages should  */
 /*             be logged instead of to standard error           */
 /*  timestamp - This indicates that messages should be prefixed */
 /*              with timestamps (and the process id)            */
-void HIDDENSYM set_log_options(int level, char *filename, int timestamp)
+void HIDDENSYM set_log_options(int level, const char *progname, const char *filename, int timestamp)
 {
 
     loglevel = level;
     if (loglevel < MSGERR)
         loglevel = MSGNONE;
+
+    if (progname)
+    {
+        logprogname = strdup(progname);
+    }
 
     if (filename)
     {
@@ -90,7 +98,6 @@ void HIDDENSYM show_msg(int level, char *fmt, ...)
 {
     va_list ap;
     int saveerr;
-    extern char *progname;
     char timestring[20];
     time_t timestamp;
 
@@ -119,7 +126,7 @@ void HIDDENSYM show_msg(int level, char *fmt, ...)
         fprintf(logfile, "%s ", timestring);
     }
 
-    fputs(progname, logfile);
+    fputs(logprogname, logfile);
 
     if (logstamp)
     {

--- a/common.h
+++ b/common.h
@@ -1,6 +1,6 @@
 /* Common functions provided in common.c */
 
-void set_log_options(int, char *, int);
+void set_log_options(int, const char *, const char *, int);
 void show_msg(int level, char *, ...);
 unsigned int resolve_ip(char *, int, int);
 

--- a/tnat64.c
+++ b/tnat64.c
@@ -29,7 +29,7 @@
 #endif
 
 /* Global configuration variables */
-char *progname = "libtnat64";   /* Name used in err msgs    */
+static const char *progname = "libtnat64";   /* Name used in err msgs    */
 
 /* Header Files */
 #include <stdio.h>
@@ -124,13 +124,13 @@ static int get_environment()
 
     /* Determine the logging level */
 #ifndef ALLOW_MSG_OUTPUT
-    set_log_options(MSGNONE, NULL, 0);
+    set_log_options(MSGNONE, progname, NULL, 0);
 #else
     if ((env = getenv("TNAT64_DEBUG")))
         loglevel = atoi(env);
     if (((env = getenv("TNAT64_DEBUG_FILE"))) && !suid)
         logfilename = env;
-    set_log_options(loglevel, logfilename, 1);
+    set_log_options(loglevel, progname, logfilename, 1);
 #endif
 
     done = 1;

--- a/validateconf.c
+++ b/validateconf.c
@@ -24,7 +24,7 @@
 */
 
 /* Global configuration variables */
-char *progname = "tnat64-validateconf";        /* Name for error msgs      */
+static const char *progname = "tnat64-validateconf";        /* Name for error msgs      */
 
 /* Header Files */
 #include <config.h>
@@ -51,6 +51,8 @@ int main(int argc, char *argv[])
     char *testhost = NULL;
     struct parsedfile config;
     int i;
+
+    set_log_options(MSGERR, progname, NULL, 0);
 
     if ((argc > 5) || (((argc - 1) % 2) != 0))
     {


### PR DESCRIPTION
Some symbols that should have not exported, were exported: loglevel, logfilename, logfile, logstamp, progname. This could lead with clashes with the application where libtnat64 was preloaded.

cc @Leseratte10