### PR TITLE
Add Github CI for automated testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+name: Run tests
+
+on: [push, pull_request]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run autoreconf
+      run:  autoreconf --install --symlink
+
+    - name: Run configure
+      run: ./configure
+
+    - name: Compile tnat64
+      run: make
+
+    - name: Run tests
+      run: make check
+
+    - name: Display detailed test results
+      if: always()
+      run: cat test-suite.log
+
+    - name: Upload test results artifact
+      if: always()
+      uses: actions/upload-artifact@v3
+      with: 
+        name: test-results
+        path: |
+          test-suite.log
+
+
+


### PR DESCRIPTION
As mentioned in #10, here's a small Github CI config that will automatically run all the tests for each commit. You can see the results [here](https://github.com/Leseratte10/tnat64/actions/runs/4883009594/jobs/8713792519). 

If you've never used Github Actions on this repository before, you might need to go to Settings -> Actions -> General -> Actions permissions and switch that from "Disable Actions" to one of the other options; I'm not sure what the Github default for these is. 

That'll display a nice green checkmark next to a commit when the tests ran successfully, and by clicking on that, you'll be able to see the test results for that commit.

If you want to change to a Meson build system later, you just need to edit the commands in the main.yml file to match the new build system instead.